### PR TITLE
Ignored newline

### DIFF
--- a/read.lisp
+++ b/read.lisp
@@ -137,6 +137,9 @@ backslash has already been consumed."
                         ;; now \x should be followed by an octal char
                         ;; code, three digits or less
                         (make-char-from-code (get-number :radix 8 :max 3)))))
+              ((#\Newline)
+                (peek-char t *stream* nil)
+                "")
               ;; the following five character names are
               ;; 'semi-standard' according to the CLHS but I'm not
               ;; aware of any implementation that doesn't implement


### PR DESCRIPTION
May I suggest to add backspace + newline as an escape sequence with the same semantics as tilde + newline in CL:FORMAT? That is, it would cause the (possibly empty) sequence of whitespace characters following the newline to be skipped:

    #?"abc\
       def"

    ⇒ "abcdef"
