### PR TITLE
Added support for name-readtables

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+Version 0.2.7
+2018-05-08
+Added support for name-readtables.
+Now interpol syntax can be activated using: (named-readtables:in-readtable :interpol-syntax).
+This way integration with SLIME and SLY is possible.
+
 Version 0.2.6
 2016-08-26
 Merge pull request #5 from agrostis/master (Hans Hübner)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ into literal strings even if your editor/IDE doesn't support them.
 Here's an example:
 
 ~~~lisp
+(named-readtables:in-readtable :interpol-syntax)
+
+
 (let ((a 42))
     #?"foo: \xC4\N{Latin capital letter U with diaeresis}\nbar: ${a}")
 "foo: ÄÜ

--- a/cl-interpol.asd
+++ b/cl-interpol.asd
@@ -35,9 +35,10 @@
 (in-package :cl-interpol-asd)
 
 (defsystem :cl-interpol
-  :version "0.2.6"
+  :version "0.2.7"
   :serial t
-  :depends-on (:cl-unicode)
+  :depends-on (:cl-unicode
+               :named-readtables)
   :components ((:file "packages")
                (:file "specials")
                (:file "util")

--- a/cl-interpol.asd
+++ b/cl-interpol.asd
@@ -35,7 +35,7 @@
 (in-package :cl-interpol-asd)
 
 (defsystem :cl-interpol
-  :version "0.2.7"
+  :version "0.2.6"
   :serial t
   :depends-on (:cl-unicode
                :named-readtables)

--- a/docs/index.html
+++ b/docs/index.html
@@ -40,6 +40,8 @@ scripts. It also provides various ways to insert arbitrary characters
 into literal strings even if your editor/IDE doesn't support them.
 Here's an example:
 <pre>
+* (ql:quickload :cl-interpol)
+* (named-readtables:in-readtable :interpol-syntax)
 * (let ((a 42))
     #?&quot;foo: \xC4\N{Latin capital letter U with diaeresis}\nbar: ${a}&quot;)
 &quot;foo: &Auml;&Uuml;
@@ -87,39 +89,31 @@ license</a> so you can basically do with it whatever you want.
 
 CL-INTERPOL together with this documentation can be downloaded from <a
 href="https://github.com/edicl/cl-interpol/archive/master.zip">Github</a>. The
-current version is 0.2.2.
+current version is 0.2.6.
 <p>
 CL-INTERPOL comes with a system definition for <a
 href="http://www.cliki.net/asdf">ASDF</a> so you can install the library with
 <pre>
-(asdf:oos 'asdf:load-op :cl-interpol)
+(asdf:load-system :cl-interpol)
 </pre>
-if you've unpacked it in a place where ASDF can find it.  It depends on <a href="https://github.com/edicl/cl-unicode/">CL-UNICODE</a>.  Installation
-via <a href="http://www.cliki.net/asdf-install">asdf-install</a>
+if you've unpacked it in a place where ASDF can find it.  It depends on <a href="https://github.com/edicl/cl-unicode/">CL-UNICODE</a> and <a href="https://github.com/melisgl/named-readtables">NAMED-READTABLES</a>.  Installation
+via <a href="http://www.cliki.net/asdf-install">asdf-install</a> or
+<a href="https://www.quicklisp.org/beta/">Quicklisp</a>
 should also be possible.
 <p>
 <b>Note:</b> Before you can actually <em>use</em> the new reader
-syntax you have to enable it with <a
-href="#enable-interpol-syntax"><code>ENABLE-INTERPOL-SYNTAX</code></a>.
+syntax you have to enable it with
+<a href="#enable-interpol-syntax"><code>ENABLE-INTERPOL-SYNTAX</code></a>
+or via named-readtables:
+<pre>(named-readtables:in-readtable :interpol-syntax)</pre>
+
 <p>
 You can run a test suite which tests most aspects of the library with
 <pre>
-(asdf:oos 'asdf:test-op :cl-interpol)
+(asdf:test-system :cl-interpol)
 </pre>
 The test suite depends on <a href="https://github.com/edicl/flexi-streams/">FLEXI-STREAMS</a>.
 <p>
-The current development version of CL-INTERPOL can be found
-at <a href="http://bknr.net/trac/browser/trunk/thirdparty">http://bknr.net/trac/browser/trunk/thirdparty</a>.
-This is the one to send <a href="#mail">patches</a> against.  Use at
-your own risk.
-<p>
-Lu&iacute;s Oliveira maintains an unofficial <a href="http://darcs.net/">darcs</a>
-repository of CL-INTERPOL
-at <a
-href="http://common-lisp.net/~loliveira/ediware/">http://common-lisp.net/~loliveira/ediware/</a>.
-
-<br>&nbsp;<br><h3><a name="mail" class=none>Support</a></h3>
-
 The development version of cl-interpol can be found <a href="https://github.com/edicl/cl-interpol" target="_new">on
 github</a>.  Please use the github issue tracking system to
 submit bug reports.  Patches are welcome, please use <a href="https://github.com/edicl/cl-interpol/pulls">GitHub pull

--- a/packages.lisp
+++ b/packages.lisp
@@ -32,11 +32,13 @@
 (defpackage :cl-interpol
   (:nicknames :interpol)
   (:use :cl :cl-unicode :cl-ppcre)
+  (:import-from :named-readtables
+                :defreadtable)
   (:export :enable-interpol-syntax
            :disable-interpol-syntax
            :*list-delimiter*
            :*outer-delimiters*
            :*inner-delimiters*
-	   :*optional-delimiters-p*
+           :*optional-delimiters-p*
            :*interpolate-format-directives*
-	   :interpol-reader))
+           :interpol-reader))

--- a/read.lisp
+++ b/read.lisp
@@ -782,3 +782,7 @@ ENABLE-INTERPOL-SYNTAX. If there was no such call, the standard
 readtable is used."
   `(eval-when (:compile-toplevel :load-toplevel :execute)
     (%disable-interpol-syntax)))
+
+(defreadtable :interpol-syntax
+   (:merge :standard)
+   (:dispatch-macro-char #\# #\? #'interpol-reader))


### PR DESCRIPTION
Now interpol syntax can be activated using: (named-readtables:in-readtable :interpol-syntax).
This way integration with SLIME and SLY is possible.

Closes issue #7 